### PR TITLE
Use a unique database session always

### DIFF
--- a/config.py
+++ b/config.py
@@ -21,7 +21,6 @@ db_plugin = sqlalchemy.Plugin(
 )
 
 Session = sessionmaker(bind=engine)
-sa_session = Session()
 
 app = application = bottle.Bottle()
 

--- a/controllers/access.py
+++ b/controllers/access.py
@@ -1,5 +1,5 @@
 import bottle
-from config import app, br, sa_session
+from config import app, br, Session
 from util.sql_alchemy_helper import SQLAlchemyHelper as sa_helper
 from models.user import User
 
@@ -26,6 +26,7 @@ def login_submit(session):
   username = bottle.request.json["username"]
   password = bottle.request.json["password"]
   
+  sa_session = Session()
   user = sa_session.query(User).filter_by(username=username).first()
 
   if(user is None):
@@ -59,6 +60,11 @@ def register():
 def register_submit(session):
   username = bottle.request.json["username"]
   password = bottle.request.json["password"]
+
+  if not username or not password:
+    return { "success": False }
+
+  sa_session = Session()
   email = bottle.request.json.get("email")
   user = User(username=username,
               password=password,

--- a/controllers/episode.py
+++ b/controllers/episode.py
@@ -1,5 +1,5 @@
 import bottle
-from config import app, br, sa_session
+from config import app, br, Session
 from sqlalchemy.orm import joinedload
 from collections import defaultdict
 
@@ -10,6 +10,9 @@ from models.show import Show
 def episodes_by_season(session, show_id):
   user = None
   user_id = session.get("user_id")
+
+  sa_session = Session()
+
   if(user_id):
     user = sa_session.query(User).filter(User.id == user_id).first()
 

--- a/controllers/episode_watch.py
+++ b/controllers/episode_watch.py
@@ -1,5 +1,5 @@
 import bottle
-from config import app, br, sa_session
+from config import app, br, Session
 from sqlalchemy.orm import joinedload
 from collections import defaultdict
 
@@ -13,6 +13,7 @@ from models.episode_watch import EpisodeWatch
 def episode_watch(session, episode_id):
   user_id = session.get("user_id")
   if(user_id):
+    sa_session = Session()
     episode_watch = sa_session.query(EpisodeWatch) \
                               .filter(EpisodeWatch.episode_id == episode_id, EpisodeWatch.user_id==user_id) \
                               .first()
@@ -25,6 +26,7 @@ def update_episode_watch(session, episode_id):
   watched = bottle.request.json["watched"]
   user_id = session["user_id"]
   if(user_id):
+    sa_session = Session()
     if(watched):
       sa_session.query(EpisodeWatch) \
                 .filter(EpisodeWatch.episode_id == episode_id, EpisodeWatch.user_id == user_id) \

--- a/controllers/home.py
+++ b/controllers/home.py
@@ -1,4 +1,4 @@
-from config import app, br, sa_session
+from config import app, br, Session
 from models.user import User
 
 @app.get('/')
@@ -6,6 +6,7 @@ def root(session):
   user = None
   user_id = session.get("user_id")
   if(user_id):
+    sa_session = Session()
     user = sa_session.query(User).filter(User.id == user_id).first()
   return br.render_html(
     br.BaseLayout({"current_user": user and user.to_dict()}, [

--- a/controllers/show.py
+++ b/controllers/show.py
@@ -3,7 +3,7 @@ import bottle
 import math
 from sqlalchemy.orm import joinedload
 from sqlalchemy import func
-from config import app, br, sa_session
+from config import app, br, Session
 
 from models.show import Show
 from models.show_follow import ShowFollow
@@ -15,6 +15,8 @@ from collections import defaultdict
 def root(session, slug):
   user = None
   user_id = session.get("user_id")
+
+  sa_session = Session()
   if(user_id):
     user = sa_session.query(User).filter(User.id == user_id).first()
 
@@ -45,6 +47,7 @@ def shows_by_page(session, page):
   user_id = session.get("user_id")
   user = None
 
+  sa_session = Session()
   if(user_id):
     user = sa_session.query(User).filter(User.id == user_id).first()
 

--- a/controllers/show_follow.py
+++ b/controllers/show_follow.py
@@ -1,5 +1,5 @@
 import bottle
-from config import app, br, sa_session
+from config import app, br, Session
 from sqlalchemy.orm import joinedload
 from collections import defaultdict
 
@@ -12,6 +12,7 @@ from models.show_follow import ShowFollow
 def show_follow(session, show_id):
   user_id = session.get("user_id")
   if(user_id):
+    sa_session = Session()
     show_follow = sa_session.query(ShowFollow) \
                             .filter(ShowFollow.show_id == show_id, ShowFollow.user_id==user_id) \
                             .first()
@@ -24,6 +25,7 @@ def update_show_follow(session, show_id):
   following = bottle.request.json["following"]
   user_id = session.get("user_id")
   if(user_id):
+    sa_session = Session()
     if(following):
       sa_session.query(ShowFollow) \
                 .filter(ShowFollow.show_id == show_id, ShowFollow.user_id == user_id) \

--- a/controllers/user.py
+++ b/controllers/user.py
@@ -3,7 +3,7 @@ import datetime
 import dateutil.relativedelta
 from sqlalchemy.orm import joinedload
 from sqlalchemy import func
-from config import app, br, sa_session
+from config import app, br, Session
 
 from models.show import Show
 from models.user import User
@@ -16,6 +16,7 @@ from collections import defaultdict
 def user(session, slug):
   current_user = None
   current_user_id = session.get("user_id")
+  sa_session = Session()
   if(current_user_id):
     current_user = sa_session.query(User).filter(User.id == current_user_id).first()
 

--- a/models/show.py
+++ b/models/show.py
@@ -5,8 +5,6 @@ from datetime import datetime
 from util.dateutil import UTC
 utc = UTC()
 
-from config import sa_session
-
 class Show(config.Base):
   __tablename__ = 'show'
 

--- a/models/tv_maze_api.py
+++ b/models/tv_maze_api.py
@@ -7,7 +7,7 @@ from util.dateutil import UTC
 utc = UTC()
 from dateutil.parser import parse
 from util.sql_alchemy_helper import SQLAlchemyHelper as sa_helper
-from config import sa_session
+from config import Session
 from datetime import datetime
 
 import pytvmaze
@@ -19,6 +19,7 @@ class TVMazeAPI(object):
 
   @staticmethod
   def fetch(show_name=None, tvmaze_id=None):
+    sa_session = Session()
     tvm_show = TVMazeAPI.tvm.get_show(show_name=show_name, maze_id=tvmaze_id)
     
     network = None
@@ -70,6 +71,7 @@ class TVMazeAPI(object):
 
   @staticmethod
   def refresh(show, tvmaze_id):
+    sa_session = Session()
     tvm_show = TVMazeAPI.tvm.get_show(show_name=show.title, maze_id=tvmaze_id)
 
     show.thetvdb_id=tvm_show.externals and tvm_show.externals.get("thetvdb")
@@ -125,6 +127,7 @@ class TVMazeAPI(object):
 
   @staticmethod
   def sync_cache(re_cache_all=False):
+    sa_session = Session()
     tvm_updates = pytvmaze.show_updates().updates
 
     show_objects = sa_session.query(Show).filter(Show.tvmaze_id.in_(tvm_updates.keys()))


### PR DESCRIPTION
Users were able to crash the site because I had a massive misunderstanding of how sqlalchemy sessions worked the first time I used it. I was using only a single session everywhere, so if at any point there was a database error it would lock up everything else accessing the database on the site... major problems. The prod log caught it and it was an easy fix though.

closes #50 